### PR TITLE
Refactor: Change batch task logging message

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -31,7 +31,7 @@ SECRET_KEY = SECRET_KEY
 SERVICE_KEY = SERVICE_KEY
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 ALLOWED_HOSTS = ['*']
 
@@ -183,7 +183,7 @@ REST_FRAMEWORK = {
 }
 
 CRONJOBS = [ 
-    ('* 0 * * *', 'research.views.batch_task_update_or_create_research', '>> '+os.path.join(BASE_DIR, 'research/batch_task.log')+' 2>&1 ')
+    ('* 0 * * *', 'research.views.batch_task_update_or_create_research', '>> '+os.path.join(BASE_DIR, 'batch_task.log')+' 2>&1 ')
 ]
 
 # Swagger

--- a/research/views.py
+++ b/research/views.py
@@ -1,10 +1,9 @@
-from datetime import date, timedelta
 import requests
 
+from datetime         import date, timedelta
 from django.db.models import Q
-from django.http import JsonResponse
-
-from rest_framework import generics
+from django.http      import JsonResponse
+from rest_framework   import generics
 
 from config.settings import SERVICE_KEY
 from research.models import (
@@ -52,12 +51,13 @@ class ResearchDataAPIController():
 
         return response.json()['data']
 
-
 def batch_task_update_or_create_research():
     """
         권상현
     """
     research_data = ResearchDataAPIController().call()
+    create_obj_cnt = 0
+    update_obj_cnt = 0
 
     for data in research_data:
         task_id = data['과제번호']
@@ -84,7 +84,10 @@ def batch_task_update_or_create_research():
             }
         )
 
-        if not is_created:
+        if is_created :
+            create_obj_cnt += 1
+
+        else:
             update_flag = False
 
             if research.target_number != target_number:
@@ -101,6 +104,17 @@ def batch_task_update_or_create_research():
 
             if update_flag:
                 research.save()
+                update_obj_cnt += 1
+    
+    """
+        12일 00시에 open api에서 받아온 데이터를 통해 1개의 신규 리서치가 등록되고 2개의 리서치 정보가 바뀌었을 경우
+        프로젝트 최상위 디렉토리에 위치한 batch_task란 이름의 로그 파일에 다음과 같이 기록 됨
+
+        '2022-05-12 log : "1" object(s) created, "2" object(s) updated.'
+    """
+    response = f'{str(date.today())} log : "{create_obj_cnt}" object(s) created, "{update_obj_cnt}" object(s) updated.'
+ 
+    return print(response)
 
 
 class ResearchHandler:


### PR DESCRIPTION
## :: 최근 작업 주제
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- batch task 실행 후 생성 될 로그 형식 변경

<br />

## :: 구현 사항 설명
1. batch task 실행 후 생성 될 로그 형식 변경
    * 12일 00시에 open api에서 받아온 데이터를 통해 1개의 신규 리서치가 등록되고 2개의 리서치 정보가 바뀌었을 경우 프로젝트 최상위 디렉토리에 위치한 batch_task란 이름의 로그 파일에 다음과 같이 기록 됨
    * >> '2022-05-12 log : "1" object(s) created, "2" object(s) updated.'
